### PR TITLE
feat: Add password recovery features: implement forget, verify, and r…

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "input-otp": "^1.4.2",
     "lucide-react": "^0.511.0",
     "next": "15.3.2",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      input-otp:
+        specifier: ^1.4.2
+        version: 1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@19.1.0)
@@ -1330,6 +1333,12 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  input-otp@1.4.2:
+    resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -3358,6 +3367,11 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  input-otp@1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   internal-slot@1.1.0:
     dependencies:

--- a/src/app/auth/forget-password/page.tsx
+++ b/src/app/auth/forget-password/page.tsx
@@ -1,0 +1,22 @@
+import ForgetPasswordForm from "@/components/ForgetPasswordForm";
+import { RectangleEllipsis } from "lucide-react";
+import Link from "next/link";
+
+const ForgetPassword = () => {
+  return (
+    <div className="w-[clamp(300px,21vw,360px)] bg-white rounded-lg border border-neutral-300">
+      <div className="p-4 flex items-center justify-between gap-2 border-b">
+        <div className="flex items-center gap-2">
+          <RectangleEllipsis />
+          <span className="font-bold ">تغيير كلمة السر</span>
+        </div>
+        <Link href="/auth/login" className="text-[#02C189] font-medium">
+          العودة{" "}
+        </Link>
+      </div>
+      <ForgetPasswordForm />
+    </div>
+  );
+};
+
+export default ForgetPassword;

--- a/src/app/auth/forget-password/page.tsx
+++ b/src/app/auth/forget-password/page.tsx
@@ -11,7 +11,7 @@ const ForgetPassword = () => {
           <span className="font-bold ">تغيير كلمة السر</span>
         </div>
         <Link href="/auth/login" className="text-[#02C189] font-medium">
-          العودة{" "}
+          العودة
         </Link>
       </div>
       <ForgetPasswordForm />

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,23 @@
+import ResetPasswordForm from "@/components/ResetPasswordForm";
+import { RectangleEllipsis } from "lucide-react";
+import Link from "next/link";
+import React from "react";
+
+function ResetPassword() {
+  return (
+    <div className="w-[clamp(300px,21vw,360px)] bg-white rounded-lg border border-neutral-300">
+      <div className="p-4 flex items-center justify-between gap-2 border-b">
+        <div className="flex items-center gap-2">
+          <RectangleEllipsis />
+          <span className="font-bold ">إعادة تعيين كلمة السر</span>
+        </div>
+        <Link href="/auth/login" className="text-[#02C189] font-medium">
+          العودة{" "}
+        </Link>
+      </div>
+      <ResetPasswordForm />
+    </div>
+  );
+}
+
+export default ResetPassword;

--- a/src/app/auth/verify-code/page.tsx
+++ b/src/app/auth/verify-code/page.tsx
@@ -11,7 +11,7 @@ const VerifyCode = () => {
           <span className="font-bold ">رمز التحقق</span>
         </div>
         <Link href="/auth/login" className="text-[#02C189] font-medium">
-          العودة{" "}
+          العودة
         </Link>
       </div>
       <VerifyCodeForm />

--- a/src/app/auth/verify-code/page.tsx
+++ b/src/app/auth/verify-code/page.tsx
@@ -1,0 +1,22 @@
+import VerifyCodeForm from "@/components/VerifyCodeForm";
+import { RectangleEllipsis } from "lucide-react";
+import Link from "next/link";
+
+const VerifyCode = () => {
+  return (
+    <div className="w-[clamp(300px,21vw,360px)] bg-white rounded-lg border border-neutral-300">
+      <div className="p-4 flex items-center justify-between gap-2 border-b">
+        <div className="flex items-center gap-2">
+          <RectangleEllipsis />
+          <span className="font-bold ">رمز التحقق</span>
+        </div>
+        <Link href="/auth/login" className="text-[#02C189] font-medium">
+          العودة{" "}
+        </Link>
+      </div>
+      <VerifyCodeForm />
+    </div>
+  );
+};
+
+export default VerifyCode;

--- a/src/components/ForgetPasswordForm.tsx
+++ b/src/components/ForgetPasswordForm.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { forgetPasswordSchema } from "@/schemas/forgetPasswordSchema";
+
+import { Form } from "@/components/ui/form";
+import { Button } from "./ui/button";
+import FormInput from "./forms/FormInput";
+import Spinner from "./Spinner";
+
+import useForgetPassword from "@/hooks/authentication/useForgetPassword";
+
+function ForgetPasswordForm() {
+  const { mutate, isPending } = useForgetPassword();
+
+  const form = useForm<forgetPasswordSchema>({
+    resolver: zodResolver(forgetPasswordSchema),
+  });
+
+  function onSubmit(values: forgetPasswordSchema) {
+    console.log("Submitted values:", values);
+    mutate(values);
+    // Here you would typically call an API to handle the password reset
+  }
+
+  return (
+    <div className="px-4 py-6">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormInput<forgetPasswordSchema>
+            control={form.control}
+            name="email"
+            label="البريد الالكتروني"
+            placeholder="example@gmail.com"
+            autoComplete="email"
+          />
+          <Button
+            type="submit"
+            className="w-full cursor-pointer"
+            disabled={isPending}
+          >
+            {isPending ? <Spinner /> : "ارسال رمز التحقق"}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}
+
+export default ForgetPasswordForm;

--- a/src/components/ForgetPasswordForm.tsx
+++ b/src/components/ForgetPasswordForm.tsx
@@ -21,7 +21,6 @@ function ForgetPasswordForm() {
   function onSubmit(values: forgetPasswordSchema) {
     console.log("Submitted values:", values);
     mutate(values);
-    // Here you would typically call an API to handle the password reset
   }
 
   return (

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -29,7 +29,7 @@ export default function LoginForm() {
   }
 
   return (
-    <div className="p-4">
+    <div className="px-4 py-6">
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
           <FormInput<loginSchema>

--- a/src/components/ResetPasswordForm.tsx
+++ b/src/components/ResetPasswordForm.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import {
+  resetPasswordSchema,
+  ResetPasswordSchema,
+} from "@/schemas/resetPasswordSchema";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { Form } from "./ui/form";
+import FormPassword from "./forms/FormPassword";
+import { Button } from "./ui/button";
+import Spinner from "./Spinner";
+import useResetPassword from "@/hooks/authentication/useResetPassword";
+import { useSearchParams } from "next/navigation";
+
+function ResetPasswordForm() {
+  const { mutate, isPending } = useResetPassword();
+  const searchParams = useSearchParams();
+  const email = searchParams.get("email") || "";
+  const form = useForm<ResetPasswordSchema>({
+    resolver: zodResolver(resetPasswordSchema),
+  });
+
+  function onSubmit(values: ResetPasswordSchema) {
+    console.log("Submitted values:", values);
+    mutate({ email, newPassword: values.password });
+    // Here you would typically call an API to handle the password reset
+  }
+
+  return (
+    <div className="px-4 py-6">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormPassword<ResetPasswordSchema>
+            control={form.control}
+            name="password"
+            label="كلمة المرور"
+            placeholder="ادخل كلمة المرور"
+            autoComplete="current-password"
+          />
+          <FormPassword<ResetPasswordSchema>
+            control={form.control}
+            name="confirmPassword"
+            label="تأكيد كلمة المرور"
+            placeholder="أعد إدخال كلمة المرور"
+            autoComplete="current-password"
+          />
+          <Button
+            type="submit"
+            className="w-full cursor-pointer"
+            disabled={isPending}
+          >
+            {isPending ? <Spinner /> : "أعد تعيين كلمة السر"}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}
+
+export default ResetPasswordForm;

--- a/src/components/VerifyCodeForm.tsx
+++ b/src/components/VerifyCodeForm.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import Spinner from "./Spinner";
+import { Form } from "./ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "./ui/button";
+import { verifyCodeSchema, VerifyCodeSchema } from "@/schemas/verifyCode";
+import useVerifyCode from "@/hooks/authentication/useVerifyCode";
+import { useSearchParams } from "next/navigation";
+
+import useForgetPassword from "@/hooks/authentication/useForgetPassword";
+import FormOTPInput from "./forms/FormOTPInput";
+
+function VerifyCodeForm() {
+  const { mutate, isPending } = useVerifyCode();
+  const { mutate: forgetPasswordMutation } = useForgetPassword();
+  const searchParams = useSearchParams();
+  const email = searchParams.get("email") || "";
+
+  const form = useForm<VerifyCodeSchema>({
+    resolver: zodResolver(verifyCodeSchema),
+  });
+
+  function onSubmit(values: VerifyCodeSchema) {
+    console.log("Submitted values:", values);
+    mutate({ ...values, email });
+    // Here you would typically call an API to handle the password reset
+  }
+
+  return (
+    <div className="px-4 py-6">
+      <div className="mb-6 text-center">
+        <h2 className="text-2xl font-bold mb-2">تحقق من رمز التأكيد</h2>
+        <p className="text-muted-foreground">
+          تم إرسال رمز التحقق إلى بريدك الإلكتروني
+        </p>
+      </div>
+
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          dir="ltr"
+          className="space-y-6"
+        >
+          <FormOTPInput<VerifyCodeSchema>
+            control={form.control}
+            name="code"
+            label="أدخل رمز التحقق المكون من 6 أرقام"
+            slotCount={6}
+          />
+
+          <Button
+            type="submit"
+            className="w-full cursor-pointer"
+            disabled={isPending}
+          >
+            {isPending ? <Spinner /> : "تحقق من الرمز"}
+          </Button>
+
+          <div className="text-center space-y-2">
+            <p className="text-sm text-muted-foreground">لم تستلم الرمز؟</p>
+            <Button
+              type="button"
+              variant="link"
+              className="text-sm"
+              onClick={() => {
+                forgetPasswordMutation({ email });
+                form.reset();
+              }}
+            >
+              إعادة إرسال الرمز
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}
+
+export default VerifyCodeForm;

--- a/src/components/forms/FormOTPInput.tsx
+++ b/src/components/forms/FormOTPInput.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "../ui/form";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "../ui/input-otp"; // adjust import path based on your structure
+
+import { Control, FieldValues, Path } from "react-hook-form";
+
+interface FormOTPInputProps<TFormValues extends FieldValues> {
+  control: Control<TFormValues>;
+  name: Path<TFormValues>;
+  label?: string;
+  description?: string;
+  slotCount?: number; // default to 6
+  className?: string;
+  slotClassName?: string;
+}
+
+export default function FormOTPInput<TFormValues extends FieldValues>({
+  control,
+  name,
+  label,
+  description,
+  slotCount = 6,
+  className,
+  slotClassName,
+}: FormOTPInputProps<TFormValues>) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className="flex flex-col items-center space-y-4">
+          {label && <FormLabel className="text-center">{label}</FormLabel>}
+          <FormControl>
+            <InputOTP
+              maxLength={slotCount}
+              value={field.value}
+              onChange={field.onChange}
+              className={className}
+            >
+              <InputOTPGroup>
+                {Array.from({ length: slotCount }).map((_, index) => (
+                  <InputOTPSlot
+                    key={index}
+                    index={index}
+                    className={slotClassName || "w-12 h-12 text-lg"}
+                  />
+                ))}
+              </InputOTPGroup>
+            </InputOTP>
+          </FormControl>
+          {description && <FormDescription>{description}</FormDescription>}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import * as React from "react"
+import { OTPInput, OTPInputContext } from "input-otp"
+import { MinusIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function InputOTP({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<typeof OTPInput> & {
+  containerClassName?: string
+}) {
+  return (
+    <OTPInput
+      data-slot="input-otp"
+      containerClassName={cn(
+        "flex items-center gap-2 has-disabled:opacity-50",
+        containerClassName
+      )}
+      className={cn("disabled:cursor-not-allowed", className)}
+      {...props}
+    />
+  )
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn("flex items-center", className)}
+      {...props}
+    />
+  )
+}
+
+function InputOTPSlot({
+  index,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  index: number
+}) {
+  const inputOTPContext = React.useContext(OTPInputContext)
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
+
+  return (
+    <div
+      data-slot="input-otp-slot"
+      data-active={isActive}
+      className={cn(
+        "data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-xs transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[3px]",
+        className
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="animate-caret-blink bg-foreground h-4 w-px duration-1000" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
+  return (
+    <div data-slot="input-otp-separator" role="separator" {...props}>
+      <MinusIcon />
+    </div>
+  )
+}
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,11 +1,19 @@
-import * as React from "react"
+"use client";
 
-import { cn } from "@/lib/utils"
+import * as React from "react";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+import { cn } from "@/lib/utils";
+
+function Input({
+  className,
+  type,
+  value,
+  ...props
+}: React.ComponentProps<"input">) {
   return (
     <input
       type={type}
+      value={value === undefined ? "" : value}
       data-slot="input"
       className={cn(
         "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
@@ -15,7 +23,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/src/hooks/authentication/useForgetPassword.ts
+++ b/src/hooks/authentication/useForgetPassword.ts
@@ -10,13 +10,12 @@ function useForgetPassword() {
       return await forgetPasswordService(data);
     },
     onSuccess: (data, variables) => {
-      console.log(data.message); // Handle success, e.g., show a success message
-      // or redirect the user to a different page
+      console.log(data.message);
 
       router.push(`/auth/verify-code?email=${variables.email}`);
     },
     onError: (error) => {
-      console.log("Error during password reset:", error);
+      console.error("Error during password reset:", error);
     },
   });
   return mutation;

--- a/src/hooks/authentication/useForgetPassword.ts
+++ b/src/hooks/authentication/useForgetPassword.ts
@@ -1,0 +1,25 @@
+import { forgetPasswordSchema } from "@/schemas/forgetPasswordSchema";
+import { forgetPasswordService } from "@/services/authenticationServices";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+function useForgetPassword() {
+  const router = useRouter();
+  const mutation = useMutation({
+    mutationFn: async (data: forgetPasswordSchema) => {
+      return await forgetPasswordService(data);
+    },
+    onSuccess: (data, variables) => {
+      console.log(data.message); // Handle success, e.g., show a success message
+      // or redirect the user to a different page
+
+      router.push(`/auth/verify-code?email=${variables.email}`);
+    },
+    onError: (error) => {
+      console.log("Error during password reset:", error);
+    },
+  });
+  return mutation;
+}
+
+export default useForgetPassword;

--- a/src/hooks/authentication/useResetPassword.ts
+++ b/src/hooks/authentication/useResetPassword.ts
@@ -1,0 +1,22 @@
+import { resetPasswordService } from "@/services/authenticationServices";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+function useResetPassword() {
+  const router = useRouter();
+  const mutation = useMutation({
+    mutationFn: resetPasswordService,
+    onSuccess: (data) => {
+      console.log(data.message); // Handle success, e.g., show a success message
+      // or redirect the user to a different page
+
+      router.push("/auth/login?message=password-reset-successful");
+    },
+    onError: (error) => {
+      console.log("Error during verify code:", error);
+    },
+  });
+  return mutation;
+}
+
+export default useResetPassword;

--- a/src/hooks/authentication/useVerifyCode.ts
+++ b/src/hooks/authentication/useVerifyCode.ts
@@ -1,0 +1,22 @@
+import { verifyCodeService } from "@/services/authenticationServices";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+function useVerifyCode() {
+  const router = useRouter();
+  const mutation = useMutation({
+    mutationFn: verifyCodeService,
+    onSuccess: (data, variables) => {
+      console.log(data.message); // Handle success, e.g., show a success message
+      // or redirect the user to a different page
+
+      router.push(`/auth/reset-password?email=${variables.email}`);
+    },
+    onError: (error) => {
+      console.log("Error during verify code:", error);
+    },
+  });
+  return mutation;
+}
+
+export default useVerifyCode;

--- a/src/hooks/authentication/useVerifyCode.ts
+++ b/src/hooks/authentication/useVerifyCode.ts
@@ -7,13 +7,11 @@ function useVerifyCode() {
   const mutation = useMutation({
     mutationFn: verifyCodeService,
     onSuccess: (data, variables) => {
-      console.log(data.message); // Handle success, e.g., show a success message
-      // or redirect the user to a different page
-
+      console.log(data.message);
       router.push(`/auth/reset-password?email=${variables.email}`);
     },
     onError: (error) => {
-      console.log("Error during verify code:", error);
+      console.error("Error during verify code:", error);
     },
   });
   return mutation;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,4 +2,6 @@ export const AUTH_ROUTES = [
   "/auth/login",
   "/auth/signup",
   "/auth/forget-password",
+  "/auth/verify-code",
+  "/auth/reset-password",
 ];

--- a/src/schemas/forgetPasswordSchema.ts
+++ b/src/schemas/forgetPasswordSchema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const forgetPasswordSchema = z.object({
+  email: z.string().email({
+    message: "البريد الالكتروني غير صالح",
+  }),
+});
+
+export type forgetPasswordSchema = z.infer<typeof forgetPasswordSchema>;

--- a/src/schemas/resetPasswordSchema.ts
+++ b/src/schemas/resetPasswordSchema.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const resetPasswordSchema = z
+  .object({
+    password: z
+      .string()
+      .min(8, {
+        message: "كلمة المرور يجب أن تتكون من 8 أحرف على الأقل",
+      })
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/,
+        "كلمة المرور يجب أن تحتوي على حرف كبير وصغير ورقم"
+      ),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "كلمة المرور وتأكيد كلمة المرور غير متطابقتين",
+    path: ["confirmPassword"],
+  });
+
+export type ResetPasswordSchema = z.infer<typeof resetPasswordSchema>;

--- a/src/schemas/verifyCode.ts
+++ b/src/schemas/verifyCode.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const verifyCodeSchema = z.object({
+  code: z.string().min(6, {
+    message: "رمز التحقق يجب أن يتكون من 6 أرقام",
+  }),
+});
+export type VerifyCodeSchema = z.infer<typeof verifyCodeSchema>;

--- a/src/services/authenticationServices.ts
+++ b/src/services/authenticationServices.ts
@@ -17,3 +17,48 @@ export async function loginsService(data: {
     throw error;
   }
 }
+
+export async function forgetPasswordService(data: IForgetPasswordRequest) {
+  try {
+    const response = await api.post<IForgetPasswordResponse>(
+      `/auth/forgot-password`,
+      data
+    );
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      throw new Error(error.response?.data || "حدث خطأ ما حاول مرة أخرى");
+    }
+    throw error;
+  }
+}
+
+export async function verifyCodeService(data: IVerifyCodeRequest) {
+  try {
+    const response = await api.post<IVerifyCodeResponse>(
+      `/auth/verify-code`,
+      data
+    );
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      throw new Error(error.response?.data || "حدث خطأ ما حاول مرة أخرى");
+    }
+    throw error;
+  }
+}
+
+export async function resetPasswordService(data: IResetPasswordRequest) {
+  try {
+    const response = await api.post<IResetPasswordResponse>(
+      `/auth/reset-password`,
+      data
+    );
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      throw new Error(error.response?.data || "حدث خطأ ما حاول مرة أخرى");
+    }
+    throw error;
+  }
+}

--- a/src/types/forgetPassword.d.ts
+++ b/src/types/forgetPassword.d.ts
@@ -1,0 +1,7 @@
+interface IForgetPasswordResponse {
+  message: string;
+}
+
+interface IForgetPasswordRequest {
+  email: string;
+}

--- a/src/types/resetPassword.d.ts
+++ b/src/types/resetPassword.d.ts
@@ -1,0 +1,7 @@
+interface IResetPasswordResponse {
+  message: string;
+}
+interface IResetPasswordRequest {
+  email: string;
+  newPassword: string;
+}

--- a/src/types/verifyCode.d.ts
+++ b/src/types/verifyCode.d.ts
@@ -1,0 +1,8 @@
+interface IVerifyCodeResponse {
+  message: string;
+}
+
+interface IVerifyCodeRequest {
+  email: string;
+  code: string;
+}


### PR DESCRIPTION
feat(auth): implement password recovery flows (forget, verify, reset)

- Added reusable form components for OTP input and general form fields
- Implemented `useForgetPassword`, `useVerifyCode`, and `useResetPassword` custom hooks using React Query
- Integrated forget password form to initiate recovery via email
- Added verify code form using OTP input component to handle 6-digit code verification
- Created reset password form with validations for new password input
- Improved form reusability and UI consistency using generic `FormInput` and `FormOTPInput` components
- Navigated user through the recovery flow using Next.js router hooks
